### PR TITLE
Show description instead of ‘can not be displayed’

### DIFF
--- a/src/components/results/detail/DocumentDetail.vue
+++ b/src/components/results/detail/DocumentDetail.vue
@@ -34,7 +34,7 @@
                       v-if="$props.file.mimetype.toLowerCase() === 'application/pdf'"
                       :src="`https://gateway.ipfs.io/ipfs/${$props.file.hash}`"
                     />
-                    <span v-else>File can not be displayed</span>
+                    <span v-else v-html="file.description"/>
                   </v-col>
                 </v-row>
 


### PR DESCRIPTION
Closes #50.