### PR TITLE
Add copy hash button

### DIFF
--- a/src/components/helpers/CopyHashButton.vue
+++ b/src/components/helpers/CopyHashButton.vue
@@ -1,0 +1,25 @@
+<template>
+  <v-btn
+    icon
+    color="grey"
+    @click.stop="copyHash"
+  >
+    <v-icon>mdi-content-copy</v-icon>
+  </v-btn>
+</template>
+
+<script>
+export default {
+  props: {
+    hash: {
+      type: String,
+      required: true,
+    },
+  },
+  methods: {
+    copyHash() {
+      navigator.clipboard.writeText(this.hash);
+    },
+  },
+};
+</script>

--- a/src/components/results/detail/MediaHeader.vue
+++ b/src/components/results/detail/MediaHeader.vue
@@ -15,6 +15,11 @@
             :hash="$props.file.hash"
             :title="$props.file.title"
           />
+          <CopyHashButton
+            class="ml-1"
+            v-if="$props.file.size"
+            :hash="$props.file.hash"
+          />
         </div>
       </v-col>
     </v-row>
@@ -34,13 +39,14 @@
 
 <script>
 import DownloadButton from '@/components/helpers/DownloadButton';
+import CopyHashButton from '@/components/helpers/CopyHashButton';
 import DetailMixin from '@/mixins/DetailMixin';
 
 export default {
   mixins: [
     DetailMixin,
   ],
-  components: { DownloadButton },
+  components: { DownloadButton, CopyHashButton },
 };
 </script>
 


### PR DESCRIPTION
Adds a copy button to the top of the result header to allow you to copy the hash and paste it into the box on another site (like https://ipfs.video ;) )