### PR TITLE
Bug fix detail page deeplink

### DIFF
--- a/src/components/results/detail/VideoDetail.vue
+++ b/src/components/results/detail/VideoDetail.vue
@@ -66,6 +66,9 @@ export default {
     MediaHeader,
     VideoPlayer,
   },
+  created() {
+    console.debug(this.file);
+  },
   computed: {
     videoOptions() {
       return {

--- a/src/components/results/detail/VideoDetail.vue
+++ b/src/components/results/detail/VideoDetail.vue
@@ -66,9 +66,6 @@ export default {
     MediaHeader,
     VideoPlayer,
   },
-  created() {
-    console.debug(this.file);
-  },
   computed: {
     videoOptions() {
       return {

--- a/src/helpers/typeHelper.js
+++ b/src/helpers/typeHelper.js
@@ -26,7 +26,7 @@ export const Types = {
   directories: 'directories',
 };
 
-export const ComponentDetailTypes = {
+export const DetailComponent = {
   text: DocumentDetail,
   images: ImageDetail,
   audio: AudioDetail,
@@ -38,4 +38,5 @@ export default {
   fileTypes,
   searchTypes,
   Types,
+  DetailComponent,
 };

--- a/src/helpers/typeHelper.js
+++ b/src/helpers/typeHelper.js
@@ -1,3 +1,9 @@
+import DocumentDetail from '@/components/results/detail/DocumentDetail';
+import ImageDetail from '@/components/results/detail/ImageDetail';
+import VideoDetail from '@/components/results/detail/VideoDetail';
+import AudioDetail from '@/components/results/detail/AudioDetail';
+import DirectoryDetail from '@/components/results/detail/DirectoryDetail';
+
 export const fileTypes = [
   'text',
   'images',
@@ -18,6 +24,14 @@ export const Types = {
   audio: 'audio',
   video: 'video',
   directories: 'directories',
+};
+
+export const ComponentDetailTypes = {
+  text: DocumentDetail,
+  images: ImageDetail,
+  audio: AudioDetail,
+  video: VideoDetail,
+  directories: DirectoryDetail,
 };
 
 export default {

--- a/src/views/Detail.vue
+++ b/src/views/Detail.vue
@@ -76,12 +76,14 @@
           v-for="(item, index) in items"
           :key="index"
         >
+          <!-- https://vuejs.org/v2/guide/components.html#Dynamic-Components-->
           <component
             :is="DetailComponent[this.fileType]"
             :file="item"
           />
         </v-carousel-item>
       </v-carousel>
+      <!-- https://vuejs.org/v2/guide/components.html#Dynamic-Components-->
       <component
         v-else
         :is="DetailComponent[this.fileType]"

--- a/src/views/Detail.vue
+++ b/src/views/Detail.vue
@@ -76,31 +76,15 @@
           v-for="(item, index) in items"
           :key="index"
         >
-          <ImageDetail
-            v-if="fileType === Types.images"
-            :file="item"
-          />
-          <DirectoryDetail
-            v-if="fileType === Types.directories"
-            :file="item"
-          />
-          <DocumentDetail
-            v-if="fileType === Types.text"
-            :file="item"
-          />
-          <AudioDetail
-            v-if="fileType === Types.audio"
-            :file="item"
-          />
-          <VideoDetail
-            v-if="fileType === Types.video"
+          <component
+            :is="DetailComponent[this.fileType]"
             :file="item"
           />
         </v-carousel-item>
       </v-carousel>
       <component
         v-else
-        :is="ComponentDetailTypes[this.fileType]"
+        :is="DetailComponent[this.fileType]"
         :file="singleItem"
       />
     </div>
@@ -109,24 +93,12 @@
 
 <script>
 import store from '@/store';
-import { Types, ComponentDetailTypes } from '@/helpers/typeHelper';
+import { Types, DetailComponent } from '@/helpers/typeHelper';
 import { apiMetadataQuery, batchSize } from '@/helpers/ApiHelper';
-import ImageDetail from '@/components/results/detail/ImageDetail';
-import DocumentDetail from '@/components/results/detail/DocumentDetail';
-import DirectoryDetail from '@/components/results/detail/DirectoryDetail';
-import VideoDetail from '@/components/results/detail/VideoDetail';
-import AudioDetail from '@/components/results/detail/AudioDetail';
 
 export default {
   beforeCreate() {
     store.commit('query/setRouteParams', this.$route.query);
-  },
-  components: {
-    ImageDetail,
-    DocumentDetail,
-    DirectoryDetail,
-    VideoDetail,
-    AudioDetail,
   },
   created() {
     if (this.selectedIndex > -1 && this.items[this.selectedIndex]?.hash === this.fileHash) {
@@ -170,7 +142,7 @@ export default {
   data() {
     return {
       Types,
-      ComponentDetailTypes,
+      DetailComponent,
       singleItem: undefined,
       carouselIndex: 0,
     };

--- a/src/views/Detail.vue
+++ b/src/views/Detail.vue
@@ -100,7 +100,7 @@
       </v-carousel>
       <component
         v-else
-        :is="componentType"
+        :is="ComponentDetailTypes[this.fileType]"
         :file="singleItem"
       />
     </div>
@@ -109,7 +109,7 @@
 
 <script>
 import store from '@/store';
-import { Types } from '@/helpers/typeHelper';
+import { Types, ComponentDetailTypes } from '@/helpers/typeHelper';
 import { apiMetadataQuery, batchSize } from '@/helpers/ApiHelper';
 import ImageDetail from '@/components/results/detail/ImageDetail';
 import DocumentDetail from '@/components/results/detail/DocumentDetail';
@@ -120,7 +120,6 @@ import AudioDetail from '@/components/results/detail/AudioDetail';
 export default {
   beforeCreate() {
     store.commit('query/setRouteParams', this.$route.query);
-    this.Types = Types;
   },
   components: {
     ImageDetail,
@@ -130,10 +129,6 @@ export default {
     AudioDetail,
   },
   created() {
-    this.$data.singleItem = {
-      hash: this.fileHash,
-    };
-
     if (this.selectedIndex > -1 && this.items[this.selectedIndex]?.hash === this.fileHash) {
       this.$data.carouselIndex = this.selectedIndex;
       this.$data.singleItem = undefined;
@@ -143,7 +138,7 @@ export default {
       })
         .then(() => {
           // take index parameter from route props, if available. Else fallback on hash match.
-          const index = this.items.findIndex((item) => item?.hash === this.fileHash);
+          const index = this.items?.findIndex((item) => item?.hash === this.fileHash);
           if (index > -1) {
             this.$data.carouselIndex = index;
             this.$data.singleItem = undefined;
@@ -174,6 +169,8 @@ export default {
   },
   data() {
     return {
+      Types,
+      ComponentDetailTypes,
       singleItem: undefined,
       carouselIndex: 0,
     };

--- a/src/views/Detail.vue
+++ b/src/views/Detail.vue
@@ -206,8 +206,8 @@ export default {
 
         // handle fetching missing items from the api
         const currentPage = Number(this.$route.query.page);
-        if (index === this.items.length - 1
-          || (index < this.items.length - 1 && this.items[index + 1] === undefined)) {
+        if (index === this.items?.length - 1
+          || (index < this.items?.length - 1 && this.items[index + 1] === undefined)) {
           console.debug('last page item: loading items for page', currentPage + 1);
           store.dispatch(`results/${this.fileType}/fetchPage`, { page: currentPage + 1 });
         } else if (index === ((currentPage - 1) * 15) && currentPage > 1) {


### PR DESCRIPTION
When opening a deeplink to a detail page without any query string (or a faulty one), the details are filled in from existing data and the metadata api. This did not work properly yet. 

Also the detail view is simplified. (I tried doing this before but somehow didn't get it to work, now it works). 