### PR TITLE
Last seen any #145

### DIFF
--- a/src/components/SearchFilters.vue
+++ b/src/components/SearchFilters.vue
@@ -143,7 +143,7 @@ export default {
         text: '<7d', value: '>now-7d',
       },
       {
-        text: 'any', value: null,
+        text: 'any', value: '*',
       },
     ],
   }),

--- a/src/components/SearchFilters.vue
+++ b/src/components/SearchFilters.vue
@@ -132,10 +132,13 @@ export default {
 
     lastSeenOptions: [
       {
-        text: '<24hr', value: '>now-24h',
+        text: '<24hr', value: '[ now-24h/h TO *]',
       },
       {
-        text: '<7d', value: '>now-7d',
+        text: '<7d', value: '[ now/h-7d TO *]',
+      },
+      {
+        text: '<30d', value: '[ now/d-30d TO *]',
       },
       {
         text: 'any', value: '*',

--- a/src/components/SearchFilters.vue
+++ b/src/components/SearchFilters.vue
@@ -91,9 +91,6 @@ import SearchMixin from '@/mixins/SearchMixin';
 import store from '@/store';
 
 export default {
-  components: {
-  },
-
   mixins: [SearchMixin],
 
   computed: {
@@ -102,7 +99,6 @@ export default {
         return store.state.query.filters.lastSeen;
       },
       set(value) {
-        // store.commit('query/setLastSeenFilter', value);
         this.search({ last_seen: value });
       },
     },
@@ -111,7 +107,6 @@ export default {
         return store.state.query.filters.size;
       },
       set(value) {
-        // store.commit('query/setSizeFilter', value);
         this.search({ size: value });
       },
     },

--- a/src/components/results/list/mixins/FileListMixin.js
+++ b/src/components/results/list/mixins/FileListMixin.js
@@ -4,6 +4,8 @@ import getResourceURL from '@/helpers/resourceURL';
 import { batchSize } from '@/helpers/ApiHelper';
 import SearchMixin from '@/mixins/SearchMixin';
 
+const resultsTotalMax = 10000;
+
 /**
  * this mixin makes file lists load their results and allows navigation
  */
@@ -23,7 +25,11 @@ export default {
       return store.getters[`results/${this.fileType}/error`];
     },
     resultsTotal() {
-      return store.getters[`results/${this.fileType}/resultsTotal`];
+      const total = store.getters[`results/${this.fileType}/resultsTotal`];
+      if (total === resultsTotalMax) {
+        return '10000+';
+      }
+      return total;
     },
     results() {
       const pageResults = store.getters[`results/${this.fileType}/pageResults`];

--- a/src/store/modules/SearchQuery.js
+++ b/src/store/modules/SearchQuery.js
@@ -5,7 +5,7 @@ const initialQuery = {
   type: 'any',
   page: 1,
   filters: {
-    lastSeen: '>now-7d',
+    lastSeen: '[ now/d-30d TO *]',
     size: null,
   },
 };


### PR DESCRIPTION
Fix #145 and:

## Tweaks to last seen filter
1. Rounding of now, allows much better caching.
2. Added 30d period.
3. Set default to 30d period (7d seems too short).

## Render 10000+ for 10000 items
10000 is the max. returned by Elasticsearch, so there's really more.