### PR TITLE
Addition of opensearch support

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -8,6 +8,7 @@
     <link rel="icon" type="image/png" href="<%= BASE_URL %>assets/images/favicon.png">
     <title><%= htmlWebpackPlugin.options.title %></title>
     <link rel="stylesheet" href="<%= BASE_URL %>assets/styles/fonts.css">
+    <link rel="search" type="application/opensearchdescription+xml" href="opensearch.xml" title="Search IPFS" >
   </head>
   <body>
     <noscript>

--- a/public/opensearch.xml
+++ b/public/opensearch.xml
@@ -1,0 +1,6 @@
+<OpenSearchDescription>
+  <ShortName>IPFS Search</ShortName>
+  <Description>IPFS Search</Description>
+  <InputEncoding>[UTF-8]</InputEncoding>
+  <Url type="text/html" template="http://localhost:8080/#/search?q={searchTerms}"/>
+</OpenSearchDescription>

--- a/public/opensearch.xml
+++ b/public/opensearch.xml
@@ -1,6 +1,6 @@
 <OpenSearchDescription xmlns="http://a9.com/-/spec/opensearch/1.1/" xmlns:moz="http://www.mozilla.org/2006/browser/search/">
-  <ShortName>IPFS Search</ShortName>
-  <Description>IPFS Search</Description>
+  <ShortName>ipfs-search.com</ShortName>
+  <Description>Search the Distributed Web</Description>
   <InputEncoding>UTF-8</InputEncoding>
-  <Url type="text/html" template="http://localhost:8080/#/search?q={searchTerms}" />
+  <Url type="text/html" template="https://ipfs-search.com/#/search?q={searchTerms}&amp;page={startPage?}" />
 </OpenSearchDescription>

--- a/public/opensearch.xml
+++ b/public/opensearch.xml
@@ -1,6 +1,6 @@
-<OpenSearchDescription>
+<OpenSearchDescription xmlns="http://a9.com/-/spec/opensearch/1.1/" xmlns:moz="http://www.mozilla.org/2006/browser/search/">
   <ShortName>IPFS Search</ShortName>
   <Description>IPFS Search</Description>
   <InputEncoding>UTF-8</InputEncoding>
-  <Url type="text/html" template="http://localhost:8080/#/search?q={searchTerms}"/>
+  <Url type="text/html" template="http://localhost:8080/#/search?q={searchTerms}" />
 </OpenSearchDescription>

--- a/public/opensearch.xml
+++ b/public/opensearch.xml
@@ -1,6 +1,6 @@
 <OpenSearchDescription>
   <ShortName>IPFS Search</ShortName>
   <Description>IPFS Search</Description>
-  <InputEncoding>[UTF-8]</InputEncoding>
+  <InputEncoding>UTF-8</InputEncoding>
   <Url type="text/html" template="http://localhost:8080/#/search?q={searchTerms}"/>
 </OpenSearchDescription>


### PR DESCRIPTION
This branch adds support for the Opensearch standard (https://github.com/dewitt/opensearch) in order to make IPFS-search discoverable by browsers and allow users to search in the browser address bar.