### PR TITLE
Feature/nsfw filter

### DIFF
--- a/src/components/detailViewComponents/ImageDetail.vue
+++ b/src/components/detailViewComponents/ImageDetail.vue
@@ -1,10 +1,11 @@
 <script setup>
+import NsfwTooltip from "@/components/shared/nsfwTooltip.vue";
 import { useDetail, detailProps } from "@/composables/useDetail";
 const props = defineProps(detailProps);
 const { resourceURL } = useDetail(props);
 
-import { useBlurExplicit } from "@/composables/BlurExplicitImagesComposable";
 import GenericDetail from "@/components/detailViewComponents/GenericDetail.vue";
+import { useBlurExplicit } from "@/composables/BlurExplicitImagesComposable";
 const { blurExplicit } = useBlurExplicit();
 </script>
 
@@ -18,12 +19,14 @@ const { blurExplicit } = useBlurExplicit();
           :src="resourceURL"
           max-height="400px"
           class="image-wrapper"
+          :class="{ blurExplicit: blurExplicit(file) }"
         >
           <template #placeholder>
             <v-row class="fill-height ma-0" align="center" justify="center">
               <v-progress-circular indeterminate color="ipfsPrimary" />
             </v-row>
           </template>
+          <NsfwTooltip :file="file" />
         </v-img>
       </v-col>
     </v-row>

--- a/src/components/searchViewComponents/ImageList.vue
+++ b/src/components/searchViewComponents/ImageList.vue
@@ -1,10 +1,10 @@
 <script setup>
+import NsfwTooltip from "@/components/shared/nsfwTooltip.vue";
 import ListBase from "./BaseList.vue";
 import HoverCard from "./subcomponents/HoverCard.vue";
 import { useFileListComposable, imports } from "@/composables/useFileListComposable";
 import { useBlurExplicit } from "@/composables/BlurExplicitImagesComposable";
 import { Types } from "@/helpers/typeHelper";
-import { mdiCog } from "@mdi/js";
 
 const fileType = Types.images;
 
@@ -34,25 +34,7 @@ const { blurExplicit } = useBlurExplicit();
                   <v-progress-circular indeterminate color="ipfsPrimary" />
                 </v-row>
               </template>
-              <v-tooltip location="bottom" align="center" activator="parent">
-                <div>
-                  <div v-if="hit.title" v-sane-html="hit.title"></div>
-                  <div v-if="blurExplicit(hit)">
-                    Blurring explicit content. See settings in menubar under
-                    <v-icon color="white" :icon="mdiCog" />
-                  </div>
-                  <div v-if="hit.nsfwClassification">
-                    {{
-                      Object.entries(hit.nsfwClassification).reduce(
-                        (p, [classifier, value]) =>
-                          `${p} ${classifier}: ${Math.round(value * 100)}%`,
-                        ""
-                      )
-                    }}
-                  </div>
-                  <div v-else>NSFW classification not available</div>
-                </div>
-              </v-tooltip>
+              <NsfwTooltip :file="hit" />
             </v-img>
           </hover-card>
         </v-col>

--- a/src/components/shared/nsfwTooltip.vue
+++ b/src/components/shared/nsfwTooltip.vue
@@ -1,0 +1,31 @@
+<script setup>
+import { mdiCog } from "@mdi/js";
+defineProps({
+  file: {
+    type: Object,
+    required: true,
+  },
+});
+import { useBlurExplicit } from "@/composables/BlurExplicitImagesComposable";
+const { blurExplicit } = useBlurExplicit();
+</script>
+<template>
+  <v-tooltip location="bottom" align="center" activator="parent">
+    <div>
+      <div v-if="file.title" v-sane-html="file.title"></div>
+      <div v-if="blurExplicit(file)">
+        Blurring explicit content. See settings in menubar under
+        <v-icon color="wfilee" :icon="mdiCog" />
+      </div>
+      <div v-if="file.nsfwClassification">
+        {{
+          Object.entries(file.nsfwClassification).reduce(
+            (p, [classifier, value]) => `${p} ${classifier}: ${Math.round(value * 100)}%`,
+            ""
+          )
+        }}
+      </div>
+      <div v-else>NSFW classification not available</div>
+    </div>
+  </v-tooltip>
+</template>

--- a/src/helpers/constants/nsfwThresholds.js
+++ b/src/helpers/constants/nsfwThresholds.js
@@ -1,9 +1,0 @@
-export const nsfwThresholds = {
-  hentai: 0.15,
-  porn: 0.15,
-  sexy: 0.3,
-};
-
-export default {
-  nsfwThresholds,
-};

--- a/src/helpers/constants/nsfwThresholds.ts
+++ b/src/helpers/constants/nsfwThresholds.ts
@@ -1,0 +1,5 @@
+export const nsfwThresholds: any = {
+  hentai: 0.15,
+  porn: 0.15,
+  sexy: 0.3,
+};

--- a/src/store/modules/query.js
+++ b/src/store/modules/query.js
@@ -20,16 +20,15 @@ export default {
   },
   getters: {
     apiQueryString: (state, getters) => (fileType) => {
+      console.log(Object.keys(state.filters));
       const filterQuery = Object.keys(state.filters)
         .filter((filter) => getters["filters/applicableFilters"].includes(filter))
         .map((filter) => getters[`filters/${filter}/toSearchQuery`])
         .filter((el) => !!el); // remove empty values before the join to avoid double spaces
 
-      return [
-        state.searchPhrase,
-        getters["filters/type/toSearchQuery"](fileType),
-        ...filterQuery,
-      ].join(" ");
+      return [state.searchPhrase, ...filterQuery, getters["filters/type/toSearchQuery"](fileType)]
+        .filter((e) => !!e)
+        .join(" ");
     },
   },
   modules: {

--- a/src/store/modules/queryFilters/filterDefinitions/nsfwFilter.ts
+++ b/src/store/modules/queryFilters/filterDefinitions/nsfwFilter.ts
@@ -1,31 +1,30 @@
 import { filterDefinition } from "./filterDefinitionInterface";
+import { nsfwThresholds } from "@/helpers/constants/nsfwThresholds";
 
-export const sizeFilterDefinition: filterDefinition = {
-  label: "Size",
-  slug: "size",
-  apiKey: "size",
+export const nsfwFilterDefinition: filterDefinition = {
+  label: "NSFW filter",
+  slug: "nsfw",
+  apiKey: "",
   items: [
     {
-      title: "0-10mb",
-      apiValue: ["<=10485760"],
-    },
-    {
-      title: "10-100mb",
-      apiValue: [">10485760", "<=104857600"],
-    },
-    {
-      title: "100mb-1gb",
-      apiValue: [">104857600", "<=1073741824"],
-    },
-    {
-      title: "1gb+",
-      value: ">1gb",
-      apiValue: [">1073741824"],
-    },
-    {
-      title: "Any",
-      apiValue: [],
+      title: "Children friendly",
+      value: "children",
+      apiValue: Object.entries({ porn: 0.15 })
+        .map(([param, val]) => `nsfw.classification.${param}:<${val}`)
+        .join(" AND "),
       default: true,
+    },
+    {
+      title: "Adult content only",
+      value: "adult",
+      apiValue: Object.entries(nsfwThresholds)
+        .map(([param, val]) => `nsfw.classification.${param}:>=${val}`)
+        .join(" "),
+    },
+    {
+      title: "All content",
+      value: "all",
+      apiValue: "",
     },
   ],
 };

--- a/src/store/modules/queryFilters/filterDefinitions/nsfwFilter.ts
+++ b/src/store/modules/queryFilters/filterDefinitions/nsfwFilter.ts
@@ -1,6 +1,11 @@
 import { filterDefinition } from "./filterDefinitionInterface";
 import { nsfwThresholds } from "@/helpers/constants/nsfwThresholds";
 
+const adultOnly = (comparator: string) =>
+  Object.entries(nsfwThresholds)
+    .map(([param, val]) => `nfsw.classification.${param}:${comparator}${val}`)
+    .join(" OR ");
+
 export const nsfwFilterDefinition: filterDefinition = {
   label: "NSFW filter",
   slug: "nsfw",
@@ -9,17 +14,13 @@ export const nsfwFilterDefinition: filterDefinition = {
     {
       title: "Children friendly",
       value: "children",
-      apiValue: Object.entries({ porn: 0.15 })
-        .map(([param, val]) => `nsfw.classification.${param}:<${val}`)
-        .join(" AND "),
+      apiValue: adultOnly("<"),
       default: true,
     },
     {
       title: "Adult content only",
       value: "adult",
-      apiValue: Object.entries(nsfwThresholds)
-        .map(([param, val]) => `nsfw.classification.${param}:>=${val}`)
-        .join(" "),
+      apiValue: adultOnly(">="),
     },
     {
       title: "All content",

--- a/src/store/modules/queryFilters/filterDefinitions/nsfwFilter.ts
+++ b/src/store/modules/queryFilters/filterDefinitions/nsfwFilter.ts
@@ -8,7 +8,7 @@ const adultOnly = (comparator: string, join = " ") =>
     .join(join);
 
 export const nsfwFilterDefinition: filterDefinition = {
-  label: "NSFW filter",
+  label: "Adult content",
   slug: "nsfw",
   apiKey: "",
   items: [
@@ -21,7 +21,7 @@ export const nsfwFilterDefinition: filterDefinition = {
     {
       title: "Adult content only",
       value: "adult",
-      apiValue: adultOnly(">=", " OR "),
+      apiValue: `(${adultOnly(">=", " OR ")})`,
     },
     {
       title: "All content",

--- a/src/store/modules/queryFilters/filterDefinitions/nsfwFilter.ts
+++ b/src/store/modules/queryFilters/filterDefinitions/nsfwFilter.ts
@@ -1,10 +1,11 @@
 import { filterDefinition } from "./filterDefinitionInterface";
 import { nsfwThresholds } from "@/helpers/constants/nsfwThresholds";
 
-const adultOnly = (comparator: string) =>
+const adultOnly = (comparator: string, join = " ") =>
   Object.entries(nsfwThresholds)
+    // FIXME: the ipfs-search index has a typo in nsfw.
     .map(([param, val]) => `nfsw.classification.${param}:${comparator}${val}`)
-    .join(" OR ");
+    .join(join);
 
 export const nsfwFilterDefinition: filterDefinition = {
   label: "NSFW filter",
@@ -12,15 +13,15 @@ export const nsfwFilterDefinition: filterDefinition = {
   apiKey: "",
   items: [
     {
-      title: "Children friendly",
-      value: "children",
+      title: "Suitable for work",
+      value: "suitable",
       apiValue: adultOnly("<"),
       default: true,
     },
     {
       title: "Adult content only",
       value: "adult",
-      apiValue: adultOnly(">="),
+      apiValue: adultOnly(">=", " OR "),
     },
     {
       title: "All content",

--- a/src/store/modules/queryFilters/filterDefinitions/nsfwFilter.ts
+++ b/src/store/modules/queryFilters/filterDefinitions/nsfwFilter.ts
@@ -1,0 +1,31 @@
+import { filterDefinition } from "./filterDefinitionInterface";
+
+export const sizeFilterDefinition: filterDefinition = {
+  label: "Size",
+  slug: "size",
+  apiKey: "size",
+  items: [
+    {
+      title: "0-10mb",
+      apiValue: ["<=10485760"],
+    },
+    {
+      title: "10-100mb",
+      apiValue: [">10485760", "<=104857600"],
+    },
+    {
+      title: "100mb-1gb",
+      apiValue: [">104857600", "<=1073741824"],
+    },
+    {
+      title: "1gb+",
+      value: ">1gb",
+      apiValue: [">1073741824"],
+    },
+    {
+      title: "Any",
+      apiValue: [],
+      default: true,
+    },
+  ],
+};

--- a/src/store/modules/queryFilters/filterSubModule.js
+++ b/src/store/modules/queryFilters/filterSubModule.js
@@ -9,9 +9,11 @@ import { languageFilterDefinition } from "./filterDefinitions/languageFilter";
 import { sizeFilterDefinition } from "./filterDefinitions/sizeFilter";
 import { lastSeenFilterDefinition } from "./filterDefinitions/lastSeenFilter";
 import {
+  nsfwFilterModule,
   selectFilterModule,
   typeFilterModule,
 } from "@/store/modules/queryFilters/filterVuexModuleGenerators";
+import { nsfwFilterDefinition } from "@/store/modules/queryFilters/filterDefinitions/nsfwFilter";
 
 const TYPE = typeFilterDefinition.slug;
 const DOCTYPE = documentsTypeFilterDefinition.slug;
@@ -22,6 +24,7 @@ const OTHERTYPE = otherTypeFilterDefinition.slug;
 const LANGUAGE = languageFilterDefinition.slug;
 const SIZE = sizeFilterDefinition.slug;
 const LASTSEEN = lastSeenFilterDefinition.slug;
+const NSFW = nsfwFilterDefinition.slug;
 
 const mutations = {
   /**
@@ -51,7 +54,7 @@ export default {
         case Types.video:
           return [VIDEOTYPE, SIZE, LASTSEEN];
         case Types.images:
-          return [IMAGETYPE, SIZE, LASTSEEN];
+          return [IMAGETYPE, NSFW, SIZE, LASTSEEN];
         case Types.other:
           return [OTHERTYPE, SIZE, LASTSEEN];
         default:
@@ -73,5 +76,6 @@ export default {
     [LANGUAGE]: selectFilterModule(languageFilterDefinition),
     [SIZE]: selectFilterModule(sizeFilterDefinition),
     [LASTSEEN]: selectFilterModule(lastSeenFilterDefinition),
+    [NSFW]: nsfwFilterModule(nsfwFilterDefinition),
   },
 };

--- a/src/store/modules/queryFilters/filterVuexModuleGenerators.js
+++ b/src/store/modules/queryFilters/filterVuexModuleGenerators.js
@@ -178,3 +178,35 @@ export const typeFilterModule = (filterProperties) =>
       }),
     },
   });
+
+/**
+ * The typefilter acts as a single select component, but to transform to search API, the
+ * multiple-select transformer is used, with a parameter of which type. This exception is
+ * necessary for requesting multiple filetypes at once (as is the case with the 'any' option)
+ * @param filterProperties
+ * @returns {{mutations: {setValue}, state, getters: {toProps, toSearchQuery}}}
+ */
+export const nsfwFilterModule = (filterProperties) =>
+  filterModule({
+    state: mapDefinitionToState(filterProperties),
+    mutations: {
+      setValue: selectFilterValue,
+    },
+    getters: {
+      // for the transformation of the type filter to the search api, we need to know the requested
+      // type, because the 'any' type requires each of the available types to be searched.
+      toSearchQuery: (state) => {
+        const value = Array.isArray(state.value) ? state.value[0] : state.value;
+        return state.items.find((item) => item.value === value)?.apiValue;
+      },
+      toProps: ({ label, slug, items, value, multiple }) => ({
+        // coerce value to primitive value (in case it is an array)
+        label,
+        slug,
+        items,
+        multiple,
+        value: Array.isArray(value) ? value[0] : value,
+        isDefault: [value].flat()[0] === items.find((item) => item.default)?.value,
+      }),
+    },
+  });

--- a/src/store/modules/queryFilters/filterVuexModuleGenerators.js
+++ b/src/store/modules/queryFilters/filterVuexModuleGenerators.js
@@ -5,11 +5,12 @@
 //
 // There a number of standard mutation/getter methods defined for standard filters
 //
-// The filterModule function explains the shape of the module:
 import { Types } from "@/helpers/typeHelper";
 import { elasticSearchEscape } from "@/helpers/ApiHelper";
 
 /**
+ * The filterModule function makes sure the module has the correct 'shape'
+ * TODO: turn this into a typescript interface and function type
  * @param state: holds label, slug, api-key and items for the filter. All of this is stateful.
  * @param setValue: set/select the value of the filter
  * @param toProps: transform the state to component props
@@ -100,6 +101,11 @@ const mapDefinitionToState = ({ label, slug, apiKey, items }) => ({
  * toProps getter, used to transform the state into props for the filter component
  * @param { ...state }
  * @returns {{multiple, label, items, value, slug}}
+ * @param label
+ * @param slug
+ * @param items
+ * @param value
+ * @param multiple
  */
 const toProps = ({ label, slug, items, value, multiple }) => ({
   label,
@@ -180,9 +186,8 @@ export const typeFilterModule = (filterProperties) =>
   });
 
 /**
- * The typefilter acts as a single select component, but to transform to search API, the
- * multiple-select transformer is used, with a parameter of which type. This exception is
- * necessary for requesting multiple filetypes at once (as is the case with the 'any' option)
+ * the nsfw filter uses multiple keys to query on, and this is not part of the
+ * (multiple) select filter query builder. So it has a custom query builder.
  * @param filterProperties
  * @returns {{mutations: {setValue}, state, getters: {toProps, toSearchQuery}}}
  */
@@ -193,20 +198,10 @@ export const nsfwFilterModule = (filterProperties) =>
       setValue: selectFilterValue,
     },
     getters: {
-      // for the transformation of the type filter to the search api, we need to know the requested
-      // type, because the 'any' type requires each of the available types to be searched.
+      toProps,
       toSearchQuery: (state) => {
         const value = Array.isArray(state.value) ? state.value[0] : state.value;
         return state.items.find((item) => item.value === value)?.apiValue;
       },
-      toProps: ({ label, slug, items, value, multiple }) => ({
-        // coerce value to primitive value (in case it is an array)
-        label,
-        slug,
-        items,
-        multiple,
-        value: Array.isArray(value) ? value[0] : value,
-        isDefault: [value].flat()[0] === items.find((item) => item.default)?.value,
-      }),
     },
   });


### PR DESCRIPTION
## Contents: NSFW filter for image search
With this filter, you can choose to have 

- only office-friendly content, this can be recognized by that none of it should be blurred. 
- only adult content, this can be recognized by that all of it is blurred
- all images; this should be a mix of blurred and non-blurred.

It also fixes the bug #229 that the detail page is not blurred when the blur setting is switched on. Explicit images on the detail page are now blurred and a tooltip shows why, just like in list view

## To test, 
switch on the blur filter, and send some queries. Verify the above

N.b. that the nsfw index went live only 27 days ago, any content added before that can not be filtered based on nsfw classification (even though you can see it in the tooltip) and will not show up in either of the first 2 options. It does show up in the last option.

## **N.b. For review**, 
what is useful is:

- high-level code review, such as: are there any nonsense comments, unused variables, unused classes/files, todos that are already done, obvious antipatterns. 
- usability/bugtesting: severe problems in texts, failing (edge) cases, etc.

Not useful is: 

- opinions, these can be put on the chat
- feature requests
- unrelated issues
- code quality comments on untouched code

please only useful comments