### PR TITLE
add system media controls to the playlist. Fixes a minor bug in templ…

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,6 @@
     "lint:fix": "eslint --ext .js,.mjs,.cjs,.jsx,.ts,.tsx,.vue src --fix",
     "prettier:check": "prettier --check .",
     "prettier:write": "prettier --write .",
-    "CC": "codeclimate analyze ./src",
     "test": "vitest watch",
     "test:once": "vitest run",
     "test:coverage": "vitest run --coverage",

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "lint:fix": "eslint --ext .js,.mjs,.cjs,.jsx,.ts,.tsx,.vue src --fix",
     "prettier:check": "prettier --check .",
     "prettier:write": "prettier --write .",
+    "CC": "codeclimate analyze ./src",
     "test": "vitest watch",
     "test:once": "vitest run",
     "test:coverage": "vitest run --coverage",

--- a/src/components/pageLayout/AudioPlayer.vue
+++ b/src/components/pageLayout/AudioPlayer.vue
@@ -12,7 +12,6 @@ import {
 } from "@mdi/js";
 import { useDisplay } from "vuetify";
 const { smAndUp, mdAndUp } = useDisplay();
-import { picsum } from "@/helpers/picsum";
 
 import {
   audioPlayer,
@@ -24,6 +23,7 @@ import {
   playlistSkipPrevious,
   nextPlaylistEntry,
   playlistSkipNext,
+  playlistActive,
 } from "@/composables/audioControls";
 
 const progress = computed({
@@ -41,7 +41,7 @@ const progress = computed({
   },
 });
 
-import { fileTitle, fileAuthor } from "@/helpers/fileHelper";
+import { fileTitle, fileAuthor, fileAlbum, fileCover } from "@/helpers/fileHelper";
 </script>
 
 <template>
@@ -69,12 +69,7 @@ import { fileTitle, fileAuthor } from "@/helpers/fileHelper";
       <v-row class="w-100">
         <v-col cols="12" xl="8" offset-xl="2" class="d-flex w-100">
           <v-avatar v-if="mdAndUp" class="my-auto ml-4" rounded="0" size="75">
-            <v-img
-              aspect-ratio="1"
-              bac
-              :src="picsum({ width: 75, height: 75, seed: audioPlayer.file?.hash })"
-            >
-            </v-img>
+            <v-img aspect-ratio="1" bac :src="fileCover(audioPlayer.file, 75, 75)"> </v-img>
             <v-icon
               size="42"
               color="white"
@@ -115,7 +110,7 @@ import { fileTitle, fileAuthor } from "@/helpers/fileHelper";
                 class="bg-ipfsPrimary-lighten-1 ml-2"
                 :size="mdAndUp ? 'large' : 'default'"
                 :icon="mdiSkipPrevious"
-                :disabled="previousPlaylistEntry() === undefined"
+                :disabled="!playlistActive || previousPlaylistEntry === undefined"
                 title="Pause"
                 @click="playlistSkipPrevious"
               />
@@ -154,7 +149,7 @@ import { fileTitle, fileAuthor } from "@/helpers/fileHelper";
                 class="bg-ipfsPrimary-lighten-1 ml-2"
                 :size="mdAndUp ? 'large' : 'default'"
                 :icon="mdiSkipNext"
-                :disabled="nextPlaylistEntry() === undefined"
+                :disabled="!playlistActive || nextPlaylistEntry === undefined"
                 title="Pause"
                 @click="playlistSkipNext"
               />

--- a/src/components/pageLayout/PlayList.vue
+++ b/src/components/pageLayout/PlayList.vue
@@ -16,9 +16,8 @@ import {
   mdiFileFind,
   mdiTrashCanOutline,
 } from "@mdi/js";
-import { picsum } from "@/helpers/picsum";
 
-import { fileTitle, fileAuthor, fileAlbum } from "@/helpers/fileHelper";
+import { fileTitle, fileAuthor, fileAlbum, fileCover } from "@/helpers/fileHelper";
 
 const playlistEntries = computed(() => store.getters["playlist/getPlaylist"].entries);
 import BlinkBlink from "../shared/BlinkBlink.vue";
@@ -64,14 +63,7 @@ import BlinkBlink from "../shared/BlinkBlink.vue";
                     <v-img
                       aspect-ratio="1"
                       bac
-                      :src="
-                        picsum({
-                          width: 85,
-                          height: 85,
-                          seed: entry.hash,
-                          grayscale: !!entry.audio?.error,
-                        })
-                      "
+                      :src="fileCover(entry, 85, 85, { grayscale: !!entry.audio?.error })"
                     >
                       <v-icon
                         v-if="entry.audio && entry.audio.error"

--- a/src/components/pageLayout/PlayList.vue
+++ b/src/components/pageLayout/PlayList.vue
@@ -19,7 +19,8 @@ import {
 
 import { fileTitle, fileAuthor, fileAlbum, fileCover } from "@/helpers/fileHelper";
 
-const playlistEntries = computed(() => store.getters["playlist/getPlaylist"].entries);
+const playlistEntries = computed(() => store.getters["playlist/getEntries"]);
+const playlistLength = computed(() => store.getters["playlist/getLength"]);
 import BlinkBlink from "../shared/BlinkBlink.vue";
 </script>
 
@@ -37,7 +38,7 @@ import BlinkBlink from "../shared/BlinkBlink.vue";
       <v-row class="w-100">
         <v-col cols="12" xl="8" offset-xl="2">
           <v-list
-            v-if="playlistEntries.length"
+            v-if="playlistLength"
             bg-color="planetarifyDark"
             lines="2"
             style="margin-left: 8px; margin-right: -24px"

--- a/src/composables/audioControls.ts
+++ b/src/composables/audioControls.ts
@@ -140,7 +140,7 @@ export const audioPlayer = ref<IAudio>({
     });
     navigator?.mediaSession?.setActionHandler("play", () => this.player?.play());
     navigator?.mediaSession?.setActionHandler("pause", () => this.player?.pause());
-    navigator.mediaSession.playbackState = "playing";
+    navigator.mediaSession.playbackState = this.playing ? "playing" : "paused";
   },
 });
 

--- a/src/composables/audioControls.ts
+++ b/src/composables/audioControls.ts
@@ -163,13 +163,14 @@ export const startPlaylist = async (index?: number) => {
   }
 };
 
+const decrease = (index: number) =>
+  loop.value && index === 0 ? store.getters["playlist/getLength"] - 1 : index - 1;
 /**
  * Find to the first former entry without errors. In case of loop, continue at the end when hitting 0.
  * If there are no other entries without errors before the current one, return undefined.
  */
 export const previousPlaylistEntry = computed(() => {
   const entries = store.getters["playlist/getEntries"];
-  const decrease = (index: number) => (loop.value && index === 0 ? entries.length - 1 : index - 1);
   let newIndex = decrease(playlistIndex.value);
   while (entries[newIndex]?.audio?.error && newIndex !== playlistIndex.value) {
     newIndex = decrease(newIndex);
@@ -184,9 +185,9 @@ export const playlistSkipPrevious = () => {
   startPlaylist(previousPlaylistEntry.value);
 };
 
+const increase = (index: number) =>
+  loop.value && index === store.getters["playlist/getLength"] - 1 ? 0 : index + 1;
 export const nextPlaylistEntry = computed(() => {
-  const increase = (index: number) =>
-    loop.value && index === store.getters["playlist/getLength"] - 1 ? 0 : index + 1;
   let newIndex = increase(playlistIndex.value);
   while (
     store.getters["playlist/getEntries"][newIndex]?.audio?.error &&

--- a/src/composables/audioControls.ts
+++ b/src/composables/audioControls.ts
@@ -171,16 +171,15 @@ export const toggleLoop = () => {
 };
 
 export const startPlaylist = async (index?: number) => {
+  const entries = store.getters["playlist/getPlaylist"].entries;
   playlistActive.value = true;
   if (index !== undefined) playlistIndex.value = index;
-  while (playlistIndex.value < store.getters["playlist/getPlaylist"].entries.length) {
-    if (!store.getters["playlist/getPlaylist"].entries[playlistIndex.value].audio?.error) {
-      await playAudioFile(
-        store.getters["playlist/getPlaylist"].entries[playlistIndex.value],
-        playlistIndex.value
-      );
+  while (playlistIndex.value < entries.length) {
+    if (!entries[playlistIndex.value].audio?.error) {
+      await playAudioFile(entries[playlistIndex.value], playlistIndex.value);
     }
     playlistIndex.value++;
+    if (playlistIndex.value === entries.length && loop.value) playlistIndex.value = 0;
   }
 };
 
@@ -190,11 +189,8 @@ export const startPlaylist = async (index?: number) => {
  */
 export const previousPlaylistEntry = computed(() => {
   const entries = store.getters["playlist/getPlaylist"].entries;
-
   const decrease = (index: number) => (loop.value && index === 0 ? entries.length - 1 : index - 1);
-
   let newIndex = decrease(playlistIndex.value);
-
   while (entries[newIndex]?.audio?.error && newIndex !== playlistIndex.value) {
     newIndex = decrease(newIndex);
   }

--- a/src/composables/audioControls.ts
+++ b/src/composables/audioControls.ts
@@ -184,13 +184,23 @@ export const startPlaylist = async (index?: number) => {
   }
 };
 
+/**
+ * Find to the first former entry without errors. In case of loop, continue at the end when hitting 0.
+ * If there are no other entries without errors before the current one, return undefined.
+ */
 export const previousPlaylistEntry = computed(() => {
-  // TODO: traceback to the last previous entry wihtout error
-  if (playlistIndex.value === 0) {
-    if (loop.value) return store.getters["playlist/getPlaylist"].entries.length - 1;
-    return undefined;
+  const entries = store.getters["playlist/getPlaylist"].entries;
+
+  const decrease = (index: number) => (loop.value && index === 0 ? entries.length - 1 : index - 1);
+
+  let newIndex = decrease(playlistIndex.value);
+
+  while (entries[newIndex]?.audio?.error && newIndex !== playlistIndex.value) {
+    newIndex = decrease(newIndex);
   }
-  return playlistIndex.value - 1;
+  // returned entry can't be the current playing entry, can't have an error, and can't be negative.
+  if (newIndex === -1 || newIndex === playlistIndex.value) return undefined;
+  return newIndex;
 });
 
 export const playlistSkipPrevious = () => {

--- a/src/composables/audioControls.ts
+++ b/src/composables/audioControls.ts
@@ -126,34 +126,28 @@ export const audioPlayer = ref<IAudio>({
   },
 
   setMediaSession() {
-    if (navigator?.mediaSession) {
-      if (playlistActive.value) {
-        navigator.mediaSession.setActionHandler("nexttrack", () => {
-          playlistSkipNext();
-        });
-        navigator.mediaSession.setActionHandler("previoustrack", () => {
-          playlistSkipPrevious();
-        });
-      } else {
-        navigator.mediaSession.setActionHandler("nexttrack", null);
-        navigator.mediaSession.setActionHandler("previoustrack", null);
-      }
-      if (this.file) {
-        navigator.mediaSession.metadata = new MediaMetadata({
-          title: fileTitle(this.file),
-          artist: fileAuthor(this.file),
-          album: fileAlbum(this.file),
-          artwork: [{ src: fileCover(this.file), sizes: "200x200", type: "image/jpg" }],
-        });
-      }
-      navigator?.mediaSession?.setActionHandler("play", () => {
-        this.player?.play();
-      });
-      navigator?.mediaSession?.setActionHandler("pause", () => {
-        this.player?.pause();
-      });
-      navigator.mediaSession.playbackState = this.playing ? "playing" : "paused";
+    if (!navigator?.mediaSession) return;
+    if (playlistActive.value) {
+      navigator.mediaSession.setActionHandler("nexttrack", playlistSkipNext);
+      navigator.mediaSession.setActionHandler("previoustrack", playlistSkipPrevious);
+    } else {
+      navigator.mediaSession.setActionHandler("nexttrack", null);
+      navigator.mediaSession.setActionHandler("previoustrack", null);
     }
+    navigator.mediaSession.metadata = new MediaMetadata({
+      title:
+        this.file && fileTitle(this.file) !== this.file.hash ? fileTitle(this.file) : "Planetarify",
+      artist: this.file && fileAuthor(this.file) ? fileAuthor(this.file) : "IPFS-search.com",
+      album: this.file ? fileAlbum(this.file) : "",
+      artwork: [{ src: fileCover(this.file), sizes: "200x200", type: "image/jpg" }],
+    });
+    navigator?.mediaSession?.setActionHandler("play", () => {
+      this.player?.play();
+    });
+    navigator?.mediaSession?.setActionHandler("pause", () => {
+      this.player?.pause();
+    });
+    navigator.mediaSession.playbackState = this.playing ? "playing" : "paused";
   },
 });
 

--- a/src/composables/audioControls.ts
+++ b/src/composables/audioControls.ts
@@ -126,7 +126,7 @@ export const audioPlayer = ref<IAudio>({
   },
 
   setMediaSession() {
-    if (!navigator?.mediaSession) return;
+    if (!navigator?.mediaSession || !this.file) return;
     if (playlistActive.value) {
       navigator.mediaSession.setActionHandler("nexttrack", playlistSkipNext);
       navigator.mediaSession.setActionHandler("previoustrack", playlistSkipPrevious);
@@ -135,19 +135,14 @@ export const audioPlayer = ref<IAudio>({
       navigator.mediaSession.setActionHandler("previoustrack", null);
     }
     navigator.mediaSession.metadata = new MediaMetadata({
-      title:
-        this.file && fileTitle(this.file) !== this.file.hash ? fileTitle(this.file) : "Planetarify",
-      artist: this.file && fileAuthor(this.file) ? fileAuthor(this.file) : "IPFS-search.com",
-      album: this.file ? fileAlbum(this.file) : "",
+      title: fileTitle(this.file) !== this.file.hash ? fileTitle(this.file) : "Planetarify",
+      artist: fileAuthor(this.file) ? fileAuthor(this.file) : "IPFS-search.com",
+      album: fileAlbum(this.file),
       artwork: [{ src: fileCover(this.file), sizes: "200x200", type: "image/jpg" }],
     });
-    navigator?.mediaSession?.setActionHandler("play", () => {
-      this.player?.play();
-    });
-    navigator?.mediaSession?.setActionHandler("pause", () => {
-      this.player?.pause();
-    });
-    navigator.mediaSession.playbackState = this.playing ? "playing" : "paused";
+    navigator?.mediaSession?.setActionHandler("play", () => this.player?.play());
+    navigator?.mediaSession?.setActionHandler("pause", () => this.player?.pause());
+    navigator.mediaSession.playbackState = "playing";
   },
 });
 

--- a/src/composables/audioControls.ts
+++ b/src/composables/audioControls.ts
@@ -135,7 +135,7 @@ export const audioPlayer = ref<IAudio>({
       navigator.mediaSession.setActionHandler("previoustrack", null);
     }
     navigator.mediaSession.metadata = new MediaMetadata({
-      title: fileTitle(this.file) !== this.file.hash ? fileTitle(this.file) : "Planetarify",
+      title: fileTitle(this.file, false) || "Planetarify",
       artist: fileAuthor(this.file) ? fileAuthor(this.file) : "IPFS-search.com",
       album: fileAlbum(this.file),
       artwork: [{ src: fileCover(this.file), sizes: "200x200", type: "image/jpg" }],

--- a/src/composables/audioControls.ts
+++ b/src/composables/audioControls.ts
@@ -185,14 +185,19 @@ export const playlistSkipPrevious = () => {
 };
 
 export const nextPlaylistEntry = computed(() => {
-  const entries = store.getters["playlist/getEntries"];
-  const increase = (index: number) => (loop.value && index === entries.length - 1 ? 0 : index + 1);
+  const increase = (index: number) =>
+    loop.value && index === store.getters["playlist/getLength"] - 1 ? 0 : index + 1;
   let newIndex = increase(playlistIndex.value);
-  while (entries[newIndex]?.audio?.error && newIndex !== playlistIndex.value) {
+  while (
+    store.getters["playlist/getEntries"][newIndex]?.audio?.error &&
+    newIndex !== playlistIndex.value
+  ) {
     newIndex = increase(newIndex);
   }
-  // returned entry can't be the current playing entry, can't have an error, and can't be negative.
-  if (newIndex === entries.length || newIndex === playlistIndex.value) return undefined;
+  // returned entry can't be the current playing entry, can't have an error,
+  // and can't be greater than the length of the playlist.
+  if (newIndex === store.getters["playlist/getLength"] || newIndex === playlistIndex.value)
+    return undefined;
   return newIndex;
 });
 

--- a/src/composables/audioControls.ts
+++ b/src/composables/audioControls.ts
@@ -120,23 +120,21 @@ export const audioPlayer = ref<IAudio>({
     this.playing = false;
     this.duration = 0;
     this.time = 0;
-    // navigator?.mediaSession?.setActionHandler("play", null);
-    // navigator?.mediaSession?.setActionHandler("pause", null);
-    // navigator?.mediaSession?.setActionHandler("stop", null);
   },
 
   setMediaSession() {
     if (!navigator?.mediaSession || !this.file) return;
-    if (playlistActive.value) {
-      navigator.mediaSession.setActionHandler("nexttrack", playlistSkipNext);
-      navigator.mediaSession.setActionHandler("previoustrack", playlistSkipPrevious);
-    } else {
-      navigator.mediaSession.setActionHandler("nexttrack", null);
-      navigator.mediaSession.setActionHandler("previoustrack", null);
-    }
+    navigator.mediaSession.setActionHandler(
+      "nexttrack",
+      playlistActive.value ? playlistSkipNext : null
+    );
+    navigator.mediaSession.setActionHandler(
+      "previoustrack",
+      playlistActive.value ? playlistSkipPrevious : null
+    );
     navigator.mediaSession.metadata = new MediaMetadata({
-      title: fileTitle(this.file, false) || "Planetarify",
-      artist: fileAuthor(this.file) ? fileAuthor(this.file) : "IPFS-search.com",
+      title: fileTitle(this.file, false) || "Planetarify Pro",
+      artist: fileAuthor(this.file) ? fileAuthor(this.file) : "IPFS-search.com - Planetarify",
       album: fileAlbum(this.file),
       artwork: [{ src: fileCover(this.file), sizes: "200x200", type: "image/jpg" }],
     });

--- a/src/composables/audioControls.ts
+++ b/src/composables/audioControls.ts
@@ -134,7 +134,7 @@ export const audioPlayer = ref<IAudio>({
     );
     navigator.mediaSession.metadata = new MediaMetadata({
       title: fileTitle(this.file, false) || "Planetarify Pro",
-      artist: fileAuthor(this.file) ? fileAuthor(this.file) : "IPFS-search.com - Planetarify",
+      artist: fileAuthor(this.file) || "IPFS-search.com - Planetarify",
       album: fileAlbum(this.file),
       artwork: [{ src: fileCover(this.file), sizes: "200x200", type: "image/jpg" }],
     });

--- a/src/helpers/fileHelper.ts
+++ b/src/helpers/fileHelper.ts
@@ -63,6 +63,6 @@ export const fileAuthor = (file: IFile): string | undefined => {
 export const fileAlbum = (file: IFile): string | undefined => {
   return file.metadata?.metadata?.["xmpDM:album"]?.[0];
 };
-export const fileCover = (file: IFile, width = 200, height = 200, options?: object): string => {
-  return picsum({ width, height, seed: file.hash, ...options });
+export const fileCover = (file?: IFile, width = 200, height = 200, options?: object): string => {
+  return picsum({ width, height, seed: file?.hash, ...options });
 };

--- a/src/helpers/fileHelper.ts
+++ b/src/helpers/fileHelper.ts
@@ -54,8 +54,10 @@ export function getFileExtension(file: IFile): string {
   return "";
 }
 
-export const fileTitle = (file: IFile): string => {
-  return file.metadata?.metadata?.["title"]?.[0] || file.title || file.hash;
+export const fileTitle = (file: IFile, returnHash = true): string | undefined => {
+  return (
+    file.metadata?.metadata?.["title"]?.[0] || file.title || (returnHash ? file.hash : undefined)
+  );
 };
 export const fileAuthor = (file: IFile): string | undefined => {
   return file.metadata?.metadata?.["dc:creator"]?.[0] || file.author || undefined;

--- a/src/helpers/fileHelper.ts
+++ b/src/helpers/fileHelper.ts
@@ -1,5 +1,6 @@
 import * as mime from "mime/lite";
 import { IFile } from "../interfaces/IFile";
+import { picsum } from "@/helpers/picsum";
 
 // Howler (audio player) requires the following extensions:
 // "mp3", "mpeg", "opus", "ogg", "oga", "wav", "aac", "caf", "m4a", "m4b",
@@ -61,4 +62,7 @@ export const fileAuthor = (file: IFile): string | undefined => {
 };
 export const fileAlbum = (file: IFile): string | undefined => {
   return file.metadata?.metadata?.["xmpDM:album"]?.[0];
+};
+export const fileCover = (file: IFile, width = 200, height = 200, options?: object): string => {
+  return picsum({ width, height, seed: file.hash, ...options });
 };

--- a/src/helpers/howlPlayer.ts
+++ b/src/helpers/howlPlayer.ts
@@ -2,6 +2,7 @@ import { IAudio } from "@/interfaces/audioInterfaces";
 import { IFile } from "@/interfaces/IFile";
 import { HowlOptions } from "howler";
 import getResourceURL from "@/helpers/resourceURL";
+import { updateMediaSession } from "@/composables/audioControls";
 
 export const errorCode = {
   "1": "User aborted request",
@@ -35,7 +36,8 @@ export const howlOptions = (
     context.playing = true;
     interval = setInterval(() => {
       context.time = context.player?.seek();
-    }, 100);
+      updateMediaSession(context);
+    }, 1000);
   },
   onpause: () => {
     context.playing = false;

--- a/src/interfaces/audioInterfaces.ts
+++ b/src/interfaces/audioInterfaces.ts
@@ -2,6 +2,7 @@ import { IFile } from "./IFile";
 
 export interface IPlaylist {
   index?: number | undefined;
+  loop?: boolean;
   entries: IFile[];
 }
 
@@ -34,6 +35,4 @@ export interface IAudio {
   pause: () => void;
   initialize: (file: IFile, options?: object) => void;
   cleanUp: () => void;
-
-  setMediaSession(): void;
 }

--- a/src/interfaces/audioInterfaces.ts
+++ b/src/interfaces/audioInterfaces.ts
@@ -34,4 +34,6 @@ export interface IAudio {
   pause: () => void;
   initialize: (file: IFile, options?: object) => void;
   cleanUp: () => void;
+
+  setMediaSession(): void;
 }

--- a/src/store/modules/playlistStore.ts
+++ b/src/store/modules/playlistStore.ts
@@ -1,5 +1,6 @@
 import { Module } from "vuex";
 import { IPlaylist } from "@/interfaces/audioInterfaces";
+import { IFile } from "@/interfaces/IFile";
 
 export interface IPlaylistStoreState {
   activePlaylist?: number | undefined;
@@ -44,10 +45,26 @@ export default <Module<IPlaylistStoreState, unknown>>{
           .forEach((entry) => (entry.audio = { error }));
       });
     },
+    toggleLoop(state) {
+      state.playlists[state.activePlaylist || 0].loop =
+        !state.playlists[state.activePlaylist || 0].loop;
+      // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+      // @ts-ignore
+      this.commit("localStorage/setPlaylist", state.playlists[state.activePlaylist || 0]);
+    },
   },
   getters: {
     getPlaylist(state): IPlaylist {
       return state.playlists?.[state.activePlaylist || 0];
+    },
+    loopState(state): boolean {
+      return state.playlists?.[state.activePlaylist || 0].loop ?? false;
+    },
+    getLength(state): number {
+      return state.playlists?.[state.activePlaylist || 0].entries.length;
+    },
+    getEntries(state): IFile[] {
+      return state.playlists?.[state.activePlaylist || 0].entries;
     },
   },
 };


### PR DESCRIPTION
- Use system controls play, pause, next track, previous track to control the player/playlist - including from your bluetooth headset.
- Get feedback about what is playing and audiocontrols on your login screen or comparable interface.

Adds mediabuttons controls, including 'cover' art. closing #246 

closing #256 
Fixes issue that playing song outside of playlist still enabled the next/previous buttons

makes 'back' button return to previous song without error